### PR TITLE
Handle conversion of json_val TypedValue data to golang strings.

### DIFF
--- a/cmd/gnmi_cli/gnmi_cli.go
+++ b/cmd/gnmi_cli/gnmi_cli.go
@@ -303,6 +303,7 @@ func readCredentials() (*client.Credentials, error) {
 		return nil, err
 	}
 	c.Password = string(pass)
+	fmt.Print("\n")
 
 	return c, nil
 }

--- a/value/value.go
+++ b/value/value.go
@@ -117,6 +117,8 @@ func ToScalar(tv *pb.TypedValue) (interface{}, error) {
 		i = ss
 	case *pb.TypedValue_BytesVal:
 		i = tv.GetBytesVal()
+	case *pb.TypedValue_JsonVal:
+		i = string(tv.GetJsonVal())
 	default:
 		return nil, fmt.Errorf("non-scalar type %+v", tv.Value)
 	}


### PR DESCRIPTION
This change is needed to display some streaming telemetry updates
with `gnmi_cli -display_type s`.