### PR TITLE
Add extra CLI auth args and README doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,155 @@ To install the CLI, run
 
     go get -u github.com/openconfig/gnmi/cmd/gnmi_cli
 
+### CLI Usage
+
+The CLI provides reference gNMI functionality for verification against server implementations.
+
+```
+./gnmi_cli --help
+Usage of ./gnmi_cli:
+  -a value
+    	Short for address.
+  -address value
+    	Address of the GNMI target to query.
+  -alsologtostderr
+    	log to standard error as well as files
+  -c uint
+    	Short for count.
+  -ca_crt string
+    	CA certificate file. Used to verify server TLS certificate.
+  -capabilities
+    	When set, CLI will perform a Capabilities request. Usage: gnmi_cli -capabilities [-proto <gnmi.CapabilityRequest>] -address <address> [other flags ...]
+  -client_crt string
+    	Client certificate file. Used for client certificate-based authentication.
+  -client_key string
+    	Client private key file. Used for client certificate-based authentication.
+  -client_types value
+    	List of explicit client types to attempt, one of: gnmi. (default gnmi)
+  -count uint
+    	Number of polling/streaming events (0 is infinite).
+  -credentials_file string
+    	File of format { "Username": "demo", "Password": "demo" }
+  -d string
+    	Short for delimiter. (default "/")
+  -delimiter string
+    	Delimiter between path nodes in query. Must be a single UTF-8 code point. (default "/")
+  -display_indent string
+    	Output line, per nesting-level indent. (default "  ")
+  -display_prefix string
+    	Per output line prefix.
+  -display_size
+    	Display the total size of query response.
+  -display_type string
+    	Display output type (g, group, s, single, p, proto). (default "group")
+  -ds
+    	Short for display_size.
+  -dt string
+    	Short for display_type. (default "group")
+  -get
+    	When set, CLI will perform a Get request. Usage: gnmi_cli -get -proto <gnmi.GetRequest> -address <address> [other flags ...]
+  -insecure
+    	When set, CLI will not verify the server certificate during TLS handshake.
+  -insecure_password string
+    	Password passed via argument for Username.
+  -insecure_username string
+    	Username passed via argument.
+  -l	Short for latency.
+  -latency
+    	Display the latency for receiving each update (Now - update timestamp).
+  -log_backtrace_at value
+    	when logging hits line file:N, emit a stack trace
+  -log_dir string
+    	If non-empty, write log files in this directory
+  -logtostderr
+    	log to standard error instead of files
+  -p string
+    	Short for request proto.
+  -pi duration
+    	Short for polling_interval. (default 30s)
+  -polling_interval duration
+    	Interval at which to poll in seconds if polling is specified for query_type. (default 30s)
+  -proto string
+    	Text proto for gNMI request.
+  -q value
+    	Short for query.
+  -qt string
+    	Short for query_type. (default "once")
+  -query value
+    	Comma separated list of queries.  Each query is a delimited list of OpenConfig path nodes which may also be specified as a glob (*).  The delimeter can be specified with the --delimiter flag.
+  -query_type string
+    	Type of result, one of: (o, once, p, polling, s, streaming). (default "once")
+  -sd duration
+    	Short for streaming_duration.
+  -server_name string
+    	When set, CLI will use this hostname to verify server certificate during TLS handshake.
+  -set
+    	When set, CLI will perform a Set request. Usage: gnmi_cli -set -proto <gnmi.SetRequest> -address <address> [other flags ...]
+  -stderrthreshold value
+    	logs at or above this threshold go to stderr
+  -streaming_duration duration
+    	Length of time to collect streaming queries (0 is infinite).
+  -t string
+    	Short for target.
+  -target string
+    	Name of the gNMI target.
+  -timeout duration
+    	Terminate query if no RPC is established within the timeout duration. (default 30s)
+  -timestamp string
+    	Specify timestamp formatting in output.  One of (<empty string>, on, raw, <FORMAT>) where <empty string> is disabled, on is human readable, raw is int64 nanos since epoch, and <FORMAT> is according to golang time.Format(<FORMAT>)
+  -ts string
+    	Short for timestamp.
+  -u	Short for updates_only.
+  -updates_only
+    	Only stream updates, not the initial sync. Setting this flag for once or polling queries will cause nothing to be returned.
+  -v value
+    	log level for V logs
+  -vmodule value
+    	comma-separated list of pattern=N settings for file-filtered logging
+  -with_user_pass
+    	When set, CLI will prompt for username/password to use when connecting to a target.
+```
+
+There are several methods of authenticating, `-with_user_pass`, `-credentials_file`, and `-insecure_username`/`-insecure_password`.
+* `-with_user_pass` will prompt the user at runtime for authentication credentials.
+* `-credentials_file` will expect a JSON file (e.g. `creds.json`) with the `Username` and `Password` fields.
+
+```json
+{
+    "Username": "demo",
+    "Password": "demo"
+}
+```
+
+* `-insecure_username` and `-insecure_password` expect the associated arguments via the CLI. This is more insecure than other methods and is not generally recommended.
+
+The gNMI CLI client can consume a textual proto format which is useful when testing.
+
+`interfaces.proto.txt`
+```proto
+ subscribe: <
+    prefix: <>
+    subscription: <
+      path: <
+            elem: <
+                name: "interfaces"
+            >
+            elem: <
+                name: "interface"
+            >
+        >
+      mode: SAMPLE
+      sample_interval: 30000000000
+    >
+    mode: STREAM
+    encoding: PROTO
+>
+```
+
+A simple example query tying together the above...
+
+`gnmi_cli -address 127.0.0.1:57400 -credentials_file creds.json -qt s -insecure -proto "$(cat interfaces.proto.txt)"`
+
 ## Client libraries
 
 The main entry point for using the client libraries is in

--- a/cmd/gnmi_cli/gnmi_cli.go
+++ b/cmd/gnmi_cli/gnmi_cli.go
@@ -35,6 +35,7 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+	"encoding/json"
 
 	"flag"
 	
@@ -71,6 +72,9 @@ var (
 	setFlag          = flag.Bool("set", false, `When set, CLI will perform a Set request. Usage: gnmi_cli -set -proto <gnmi.SetRequest> -address <address> [other flags ...]`)
 
 	withUserPass = flag.Bool("with_user_pass", false, "When set, CLI will prompt for username/password to use when connecting to a target.")
+	insecureUsername = flag.String("insecure_username", "", "Username passed via argument.")
+	insecurePassword = flag.String("insecure_password", "", "Password passed via argument for Username.")
+	credentialsFile = flag.String("credentials_file", "", `File of format { "Username": "demo", "Password": "demo" }`)
 
 	// Certificate files.
 	caCert     = flag.String("ca_crt", "", "CA certificate file. Used to verify server TLS certificate.")
@@ -133,8 +137,33 @@ func main() {
 		log.Exit("--address must be set")
 	}
 	if *withUserPass {
+		if *insecureUsername != "" || *insecurePassword != "" {
+			log.Exit("Do not pass --insecure_username or --insecure_password if prompting --with_user_pass")
+		} else if *credentialsFile != "" {
+			log.Exit("Do not pass --credentials_file file if prompting --with_user_pass")
+		}
 		var err error
 		q.Credentials, err = readCredentials()
+		if err != nil {
+			log.Exit(err)
+		}
+	} else if *insecureUsername != "" || *insecurePassword != "" {
+		if *credentialsFile != "" {
+			log.Exit("Do not pass --credentials_file with --insecure_username or --insecure_password")
+		}
+		if *insecureUsername == "" {
+			log.Exit("Must supply --insecure_username with --insecure_password")
+		}
+		if *insecurePassword == "" {
+			log.Exit("Must supply --insecure_password with --insecure_username")
+		}
+		q.Credentials = &client.Credentials{
+			Username: *insecureUsername,
+			Password: *insecurePassword,
+		}
+	} else if *credentialsFile != "" {
+		var err error
+		q.Credentials, err = readCredentialsFile(*credentialsFile)
 		if err != nil {
 			log.Exit(err)
 		}
@@ -305,6 +334,21 @@ func readCredentials() (*client.Credentials, error) {
 	c.Password = string(pass)
 
 	return c, nil
+}
+
+func readCredentialsFile(filename string) (*client.Credentials, error) {
+	creds := &client.Credentials{}
+
+	credFile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(credFile, &creds)
+	if err != nil {
+		return nil, err
+	}
+
+	return creds, nil
 }
 
 func parseQuery(query, delim string) ([]string, error) {


### PR DESCRIPTION
Adds some ability for those running `gnmi_cli` to use either a JSON file containing `Username`/`Password` or directly as args with `-insecure_username`/`-insecure_password` for authentication.

Also adds some usage documentation to make reference tooling easier to onboard/use. The docs should probably be verified. :)