### PR TITLE
Add support for converting TypedValue_JsonIetfVal

### DIFF
--- a/value/value.go
+++ b/value/value.go
@@ -117,6 +117,8 @@ func ToScalar(tv *pb.TypedValue) (interface{}, error) {
 		i = ss
 	case *pb.TypedValue_BytesVal:
 		i = tv.GetBytesVal()
+	case *pb.TypedValue_JsonIetfVal:
+		i = string(tv.GetJsonIetfVal())
 	default:
 		return nil, fmt.Errorf("non-scalar type %+v", tv.Value)
 	}


### PR DESCRIPTION
When using the gnmi_cli I am getting an error saying that the client was unable to display the data. The data type is JsonIetfVal. This change fixes my issue, is this the correct way to add support for this data type?