### PR TITLE
Update example to match the updated Target proto

### DIFF
--- a/cmd/gnmi_collector/docker/config/example.cfg
+++ b/cmd/gnmi_collector/docker/config/example.cfg
@@ -18,7 +18,7 @@ request: <
 target: <
   key: "target1"
   value: <
-    address: "192.0.2.1:10162"
+    addresses: "192.0.2.1:10162"
     request: "interfaces"
     credentials: <
       username: "username"


### PR DESCRIPTION
Example now uses `addresses` instead of `address`. This reflects the change
made to target.proto done by @mkhsueh