### PR TITLE
connection: fix goroutine in TestConcurrentDialErr()

### DIFF
--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc"
 	"github.com/openconfig/gnmi/unimplemented"
+	"google.golang.org/grpc"
 
 	pb "github.com/openconfig/gnmi/proto/gnmi"
 )
@@ -241,9 +241,6 @@ func TestConcurrentDialErr(t *testing.T) {
 		go func() {
 			<-start
 			_, _, err := m.Connection(ctx, "")
-			if err == nil {
-				t.Fatal("got no error, want error")
-			}
 			errs <- err
 			wg.Done()
 		}()
@@ -252,14 +249,12 @@ func TestConcurrentDialErr(t *testing.T) {
 	wg.Wait()
 
 	close(errs)
-	var prevErr error
-	for err := range errs {
-		if prevErr == nil {
-			prevErr = err
-		}
-		if err != prevErr {
-			t.Fatal("got different error instance, want same")
-		}
+
+	err1 := <-errs
+	err2 := <-errs
+
+	if err1 != err2 || err1 == nil {
+		t.Fatalf("err1:%q err2:%q should be the same and non-nil", err1, err2)
 	}
 }
 


### PR DESCRIPTION
`TestConcurrentDialErr()` was using `testing.T.Fatal()` inside a goroutine. `T.Fatal()` is a convenience function that combines `T.Log()` and `T.FailNow()`. From the go doc for `T.FailNow()`:

> FailNow must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test.

This moves `t.Fatal()` out of the goroutine, and puts the check for a `nil` error together with the check for equality between the two errors sent down the `errs` channel. It also logs the found errors.
