### PR TITLE
Added extension ID to be used for exporting Juniper telemetry header.

### DIFF
--- a/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/gnmi_ext/gnmi_ext.proto
@@ -47,6 +47,11 @@ enum ExtensionID {
   // MUST link to a reference describing their implementation.
 
   // Juniper Telemetry header
+  // The extension proto file is named as GnmiJuniperTelemetryHeaderExtension.proto
+  // for all Junos releases starting from 21.3
+  // and it is found in each release folders of the following github repo
+  // https://github.com/Juniper/telemetry
+  // Implementation details can be found at https://kb.juniper.net/KB36506
   EID_JUNIPER_TELEMETRY_HEADER = 1;
 
   // An experimental extension that may be used during prototyping of a new

--- a/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/gnmi_ext/gnmi_ext.proto
@@ -46,6 +46,9 @@ enum ExtensionID {
   // New extensions are to be defined within this enumeration - their definition
   // MUST link to a reference describing their implementation.
 
+  // Juniper Telemetry header
+  EID_JUNIPER_TELEMETRY_HEADER = 1;
+
   // An experimental extension that may be used during prototyping of a new
   // extension.
   EID_EXPERIMENTAL = 999;


### PR DESCRIPTION
The extension ID will be used to export the telemetry header used by Juniper for exporting key information for debugging as well as for use by collectors. Details about the message that is exported is present here:
https://github.com/Juniper/telemetry/blob/master/20.1/20.1R1/protos/GnmiJuniperTelemetryHeader.proto
