### PR TITLE
Add/change java options to proto sources

### DIFF
--- a/proto/collector/collector.proto
+++ b/proto/collector/collector.proto
@@ -18,6 +18,9 @@ syntax = "proto3";
 package gnmi;
 
 option go_package = "github.com/openconfig/gnmi/proto/collector;gnmi";
+option java_multiple_files = true;
+option java_outer_classname = "CollectorProto";
+option java_package = "com.github.openconfig.gnmi.proto.collector";
 
 service Collector {
   // Reconnect requests that the existing connections for one or more specified

--- a/proto/gnmi/gnmi.proto
+++ b/proto/gnmi/gnmi.proto
@@ -42,7 +42,7 @@ option (gnmi_service) = "0.7.0";
 option go_package = "github.com/openconfig/gnmi/proto/gnmi";
 option java_multiple_files = true;
 option java_outer_classname = "GnmiProto";
-option java_package = "com.github.gnmi.proto";
+option java_package = "com.github.openconfig.gnmi.proto.gnmi";
 
 service gNMI {
   // Capabilities allows the client to retrieve the set of capabilities that

--- a/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/gnmi_ext/gnmi_ext.proto
@@ -22,6 +22,9 @@ syntax = "proto3";
 package gnmi_ext;
 
 option go_package = "github.com/openconfig/gnmi/proto/gnmi_ext";
+option java_multiple_files = true;
+option java_outer_classname = "GnmiExtProto";
+option java_package = "com.github.openconfig.gnmi.proto.gnmi_ext";
 
 // The Extension message contains a single gNMI extension.
 message Extension {

--- a/proto/target/target.proto
+++ b/proto/target/target.proto
@@ -22,6 +22,9 @@ package target;
 import "github.com/openconfig/gnmi/proto/gnmi/gnmi.proto";
 
 option go_package = "github.com/openconfig/gnmi/proto/target";
+option java_multiple_files = true;
+option java_outer_classname = "TargetProto";
+option java_package = "com.github.openconfig.gnmi.proto.target";
 
 // Configuration holds all information necessary for a caching gNMI collector
 // to establish subscriptions to a list of gNMI targets.


### PR DESCRIPTION
Add/change java options to proto sources:
- Update `java_package` option in `gnmi.proto` to better align with `go_package` option.
- Add various java options to remaining proto sources.