### PR TITLE
avoid panic case in func Equal(a, b *pb.TypedValue) bool

### DIFF
--- a/value/value.go
+++ b/value/value.go
@@ -162,51 +162,51 @@ func decimalToFloat(d *pb.Decimal64) float32 {
 // handles only the primitive types and ScalarArrays and returns false for all
 // other types.
 func Equal(a, b *pb.TypedValue) bool {
-	switch av := a.Value.(type) {
+	switch av := a.GetValue().(type) {
 	case *pb.TypedValue_StringVal:
-		bv, ok := b.Value.(*pb.TypedValue_StringVal)
+		bv, ok := b.GetValue().(*pb.TypedValue_StringVal)
 		if !ok {
 			return false
 		}
 		return av.StringVal == bv.StringVal
 	case *pb.TypedValue_IntVal:
-		bv, ok := b.Value.(*pb.TypedValue_IntVal)
+		bv, ok := b.GetValue().(*pb.TypedValue_IntVal)
 		if !ok {
 			return false
 		}
 		return av.IntVal == bv.IntVal
 	case *pb.TypedValue_UintVal:
-		bv, ok := b.Value.(*pb.TypedValue_UintVal)
+		bv, ok := b.GetValue().(*pb.TypedValue_UintVal)
 		if !ok {
 			return false
 		}
 		return av.UintVal == bv.UintVal
 	case *pb.TypedValue_BoolVal:
-		bv, ok := b.Value.(*pb.TypedValue_BoolVal)
+		bv, ok := b.GetValue().(*pb.TypedValue_BoolVal)
 		if !ok {
 			return false
 		}
 		return av.BoolVal == bv.BoolVal
 	case *pb.TypedValue_BytesVal:
-		bv, ok := b.Value.(*pb.TypedValue_BytesVal)
+		bv, ok := b.GetValue().(*pb.TypedValue_BytesVal)
 		if !ok {
 			return false
 		}
 		return string(av.BytesVal) == string(bv.BytesVal)
 	case *pb.TypedValue_FloatVal:
-		bv, ok := b.Value.(*pb.TypedValue_FloatVal)
+		bv, ok := b.GetValue().(*pb.TypedValue_FloatVal)
 		if !ok {
 			return false
 		}
 		return av.FloatVal == bv.FloatVal
 	case *pb.TypedValue_DecimalVal:
-		bv, ok := b.Value.(*pb.TypedValue_DecimalVal)
+		bv, ok := b.GetValue().(*pb.TypedValue_DecimalVal)
 		if !ok {
 			return false
 		}
 		return av.DecimalVal.Digits == bv.DecimalVal.Digits && av.DecimalVal.Precision == bv.DecimalVal.Precision
 	case *pb.TypedValue_LeaflistVal:
-		bv, ok := b.Value.(*pb.TypedValue_LeaflistVal)
+		bv, ok := b.GetValue().(*pb.TypedValue_LeaflistVal)
 		if !ok {
 			return false
 		}

--- a/value/value_test.go
+++ b/value/value_test.go
@@ -325,6 +325,11 @@ func TestEqual(t *testing.T) {
 		},
 		// Equality is not checked, expect false.
 		{
+			name: "Nil values not compared",
+			a:    nil,
+			b:    nil,
+		},
+		{
 			name: "Empty values not compared",
 			a:    &pb.TypedValue{},
 			b:    &pb.TypedValue{},


### PR DESCRIPTION
This PR avoids panic when using `func Equal(a, b *pb.TypedValue) bool` with a or b being nil.
This is done by using `TypedValue.GetValue()` instead of `TypedValue.Value`