### PR TITLE
Marking of 'suppress_redundant' and 'heartbeat_interval' for deprecation

### DIFF
--- a/proto/gnmi/gnmi.proto
+++ b/proto/gnmi/gnmi.proto
@@ -292,11 +292,11 @@ message Subscription {
   uint64 sample_interval = 3;       // ns between samples in SAMPLE mode.
   // Indicates whether values that have not changed should be sent in a SAMPLE
   // subscription.
-  bool suppress_redundant = 4;
+  bool suppress_redundant = 4 [deprecated=true];
   // Specifies the maximum allowable silent period in nanoseconds when
   // suppress_redundant is in use. The target should send a value at least once
   // in the period specified.
-  uint64 heartbeat_interval = 5;
+  uint64 heartbeat_interval = 5 [deprecated=true];
 }
 
 // SubscriptionMode is the mode of the subscription, specifying how the


### PR DESCRIPTION
As has been discussed prior OOB, I would like to initiate this PR to kick off
RFC regarding deprecation and possible future removal of the
`suppress_redundant` and `heartbeat_interval` fields in favor of alternate
options to various problem statements of determining liveliness.

NOTE: This PR is incomplete within this repository as well as the potential
removal from the openconfig-telemetry YANG schema that can be determined after
consensus for deprecation/removal.

Related problem statements:
- To determine liveliness of a long running RPC (especially important on low
  volume subscriptions)
- To satisfy middleboxes that hold state to not expire sessions (NAT, Stateful
  FW, etc..)
- To request a data "refresh" (There are already alternate solutions here)
- *Feel free to add more*

Should the instruction of a 'keepalive' exist at the RPC/message layer?

If so, then does it make sense to duplicate work in the RPC design everytime
these characteristics are shared?

There are various other services related to OpenConfig/P4 that share similar
characteristics but do not implement RPC level instructions for keepalives

Is it best served by the protocol stacks - gRPC/HTTP2 infra (keepalive/PING)?

If so, are all cases and language bindings accounted for where this would
suffice?
