### PR TITLE
Marking of 'QOSMarking' for deprecation

### DIFF
--- a/proto/gnmi/gnmi.proto
+++ b/proto/gnmi/gnmi.proto
@@ -256,7 +256,8 @@ message SubscriptionList {
   repeated Subscription subscription = 2;   // Set of subscriptions to create.
   // Whether target defined aliases are allowed within the subscription.
   bool use_aliases = 3;
-  QOSMarking qos = 4;                       // DSCP marking to be used.
+  // DSCP marking to be used.
+  QOSMarking qos = 4 [deprected=true];
   // Mode of the subscription.
   enum Mode {
     STREAM = 0; // Values streamed by the target (Sec. 3.5.1.5.2).


### PR DESCRIPTION
Per https://github.com/openconfig/gnmi/issues/45, I would like to initiate
deprecation of the `QOSMarking` field in favor of static configuration per each
service or grpc-server as a whole.

YANG configuration node support will need to still be discussed since services
are currently a leaf-list w/o per service configuration attributes.
