### PR TITLE
Add timestamp field to Update message

### DIFF
--- a/proto/gnmi/gnmi.proto
+++ b/proto/gnmi/gnmi.proto
@@ -37,7 +37,7 @@ extend google.protobuf.FileOptions {
 
 // gNMI_service is the current version of the gNMI service, returned through
 // the Capabilities RPC.
-option (gnmi_service) = "0.7.0";
+option (gnmi_service) = "0.8.0";
 
 option go_package = "github.com/openconfig/gnmi/proto/gnmi";
 option java_multiple_files = true;
@@ -100,6 +100,7 @@ message Update {
   Value value = 2 [deprecated=true];  // The value (value) for the update.
   TypedValue val = 3;                 // The explicitly typed update value.
   uint32 duplicates = 4;              // Number of coalesced duplicates.
+  int64 timestamp = 5;                // Timestamp in nanoseconds since Epoch.
 }
 
 // TypedValue is used to encode a value being sent between the client and


### PR DESCRIPTION
Currently, the specification as defined attaches a `timestamp` field to
the `Notification` message and a `Notification` message can contain one
or more `Update` messages.  The `timestamp` field is defined as the
following:

```
The time at which the data was collected by the device from the
underlying source, or the time that the target generated the
Notification message (in the case that the data does not reflect an
underlying data source). This value is always represented according to
the definition in 2.2.1.
```

In various pipelines, many data sources can contribute to the data that
is packed in a single `Notification` message however the `timestamp` can
only represent the coalesced view.  An example of this is data sources from a
distributed system (e.g. linecards) where hardware timestamps can represent the
true source prior to the aggregation and serialization towards the ultimate
TCP/gRPC session.  The true "underlying source" timestamp is then lost and/or
only representative of the single packed `Notification` that aggretates these
`Update` messages.

This proposal is to add an optional `timestamp` field to the `Update`
message in order to have the ability to represent the true data source
timestamp.  The `timestamp` field at the `Notification` message is retained for
backwards compatibility, the ability for an implementation to choose to support
1 or both timestamps and in the event of supporting both, gives the ability to
determine potential issues within the system pipeline by calculating deltas
from the original data sources.

If the proposal is accepted, relevant gNMI specification documents will be
updated in a subsequent commit.
