### PR TITLE
typo fix: festClientSend -> TestClientSend

### DIFF
--- a/testing/fake/gnmi/gnmi_test.go
+++ b/testing/fake/gnmi/gnmi_test.go
@@ -269,7 +269,7 @@ func TestClientCreate(t *testing.T) {
 	}
 }
 
-func festClientSend(t *testing.T) {
+func TestClientSend(t *testing.T) {
 	defaultConfig := &fpb.Config{
 		Target: "arista",
 		Port:   -1,


### PR DESCRIPTION
Update the function name from festClientSend to TestClientSend.