### PR TITLE
Commit confirmed extension proto

### DIFF
--- a/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/gnmi_ext/gnmi_ext.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 // extensions defined outside of this package.
 package gnmi_ext;
 
+import "google/protobuf/duration.proto";
+
 option go_package = "github.com/openconfig/gnmi/proto/gnmi_ext";
 
 // The Extension message contains a single gNMI extension.
@@ -30,6 +32,7 @@ message Extension {
     // Well known extensions.
     MasterArbitration master_arbitration = 2;  // Master arbitration extension.
     History history = 3;                       // History extension.
+    Commit commit = 4;                         // Commit confirmed extension.
   }
 }
 
@@ -88,4 +91,24 @@ message History {
 message TimeRange {
   int64 start = 1; // Nanoseconds since the epoch
   int64 end = 2;   // Nanoseconds since the epoch
+}
+
+// Commit confirmed extension allows automated revert of a configuration after
+// certain duration if an explicit confirmation is not issued. This duration can
+// be used for testing the network device to verify the configuration.
+// It also allows explicit cancellation of the commit during the rollback duration
+// time window if client determine that the configuration needs to be reverted.
+// The document about gNMI commit confirmed can be found at
+// https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-commit-confirmed.md
+message Commit {
+  // Maximum duration to wait for a confirmaton before reverting the commit.
+  google.protobuf.Duration rollback_duration = 1;
+  oneof id {
+    // commit_id indicates that this is a new commit request with given ID.
+    string commit_id = 2;
+    // confirm_id indicates that this is a confirmaton request for the given ID.
+    string confirm_id = 3;
+    // cancel_id indicates that this is a cancellation request for the given ID.
+    string cancel_id = 4;
+  }
 }

--- a/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/gnmi_ext/gnmi_ext.proto
@@ -108,9 +108,10 @@ message Commit {
   }
 }
 
-// Create a new commit request.
+// Create a new commit confirmed request.
 message CommitRequest {
-  // Commit id for the request.
+  // Commit id for the request. ID must be generated at the client side, it can be used
+  // to confirm or cancel the request without the rollback_duration interval.
   string id = 1;
   // Maximum duration to wait for a confirmaton before reverting the commit.
   google.protobuf.Duration rollback_duration = 2;
@@ -118,12 +119,12 @@ message CommitRequest {
 
 // Confirm an on-going commit.
 message CommitConfirm {
-  // Commit id that requires confirmation.
+  // Commit id of the on-going commit that requires confirmation.
   string id = 1;
 }
 
 // Cancel an on-going commit.
 message CommitCancel {
-  // Commit id that requires cancellation.
+  // Commit id of the on-going commit that requires cancellation.
   string id = 1;
 }

--- a/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/gnmi_ext/gnmi_ext.proto
@@ -95,20 +95,35 @@ message TimeRange {
 
 // Commit confirmed extension allows automated revert of a configuration after
 // certain duration if an explicit confirmation is not issued. This duration can
-// be used for testing the network device to verify the configuration.
-// It also allows explicit cancellation of the commit during the rollback duration
-// time window if client determine that the configuration needs to be reverted.
+// be used to verify the configuration.
+// It also allows explicit cancellation of the commit during the time window of rollback
+// duration if client determine that the configuration needs to be reverted.
 // The document about gNMI commit confirmed can be found at
 // https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-commit-confirmed.md
 message Commit {
-  // Maximum duration to wait for a confirmaton before reverting the commit.
-  google.protobuf.Duration rollback_duration = 1;
-  oneof id {
-    // commit_id indicates that this is a new commit request with given ID.
-    string commit_id = 2;
-    // confirm_id indicates that this is a confirmaton request for the given ID.
-    string confirm_id = 3;
-    // cancel_id indicates that this is a cancellation request for the given ID.
-    string cancel_id = 4;
+  oneof action {
+    CommitRequest commit = 1;
+    CommitConfirm confirm = 2;
+    CommitCancel cancel = 3;
   }
+}
+
+// Create a new commit request.
+message CommitRequest {
+  // Commit id for the request.
+  string id = 1;
+  // Maximum duration to wait for a confirmaton before reverting the commit.
+  google.protobuf.Duration rollback_duration = 2;
+}
+
+// Confirm an on-going commit.
+message CommitConfirm {
+  // Commit id that requires confirmation.
+  string id = 1;
+}
+
+// Cancel an on-going commit.
+message CommitCancel {
+  // Commit id that requires cancellation.
+  string id = 1;
 }

--- a/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/gnmi_ext/gnmi_ext.proto
@@ -93,38 +93,41 @@ message TimeRange {
   int64 end = 2;   // Nanoseconds since the epoch
 }
 
-// Commit confirmed extension allows automated revert of a configuration after
-// certain duration if an explicit confirmation is not issued. This duration can
-// be used to verify the configuration.
-// It also allows explicit cancellation of the commit during the time window of rollback
-// duration if client determine that the configuration needs to be reverted.
+// Commit confirmed extension allows automated revert of the configuration after
+// certain duration if an explicit confirmation is not issued. It allows explicit
+// cancellation of the commit during the rollback window. There cannot be more
+// than one commit active at a given time.
 // The document about gNMI commit confirmed can be found at
 // https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-commit-confirmed.md
 message Commit {
+  // ID is provided by the client during the commit request. During confirm and cancel
+  // actions the provided ID should match the ID provided during commit.
+  // If ID is not passed in any actions server shall return error.
+  // Required.
+  string id = 1;
   oneof action {
-    CommitRequest commit = 1;
-    CommitConfirm confirm = 2;
-    CommitCancel cancel = 3;
+    // commit action creates a new commit. If a commit is on-going, server returns error.
+    CommitRequest commit = 2;
+    // confirm action will confirm an on-going commit, the ID provided during confirm
+    // should match the on-going commit ID.
+    CommitConfirm confirm = 3;
+    // cancel action will cancel an on-going commit, the ID provided during cancel
+    // should match the on-going commit ID.
+    CommitCancel cancel = 4;
   }
 }
 
-// Create a new commit confirmed request.
+// CommitRequest is used to create a new confirmed commit. It hold additional
+// parameter requried for commit action.
 message CommitRequest {
-  // Commit id for the request. ID must be generated at the client side, it can be used
-  // to confirm or cancel the request without the rollback_duration interval.
-  string id = 1;
   // Maximum duration to wait for a confirmaton before reverting the commit.
-  google.protobuf.Duration rollback_duration = 2;
+  google.protobuf.Duration rollback_duration = 1;
 }
 
-// Confirm an on-going commit.
-message CommitConfirm {
-  // Commit id of the on-going commit that requires confirmation.
-  string id = 1;
-}
+// CommitConfirm is used to confirm an on-going commit. It hold additional
+// parameter requried for confirm action.
+message CommitConfirm {}
 
-// Cancel an on-going commit.
-message CommitCancel {
-  // Commit id of the on-going commit that requires cancellation.
-  string id = 1;
-}
+// CommitCancel is used to cancel an on-going commit. It hold additional
+// parameter requried for cancel action.
+message CommitCancel {}


### PR DESCRIPTION
This is a supporting PR for https://github.com/openconfig/reference/issues/197.  Older discussion and reference/handling document PR can be found here: https://github.com/openconfig/reference/pull/196


Netconf [rfc6241](https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.1) has a definition for `confirmed commit`. as follow-
```
  If the <persist> element is not given in the confirmed commit
   operation, any follow-up commit and the confirming commit MUST be
   issued on the same session that issued the confirmed commit.  If the
   <persist> element is given in the confirmed <commit> operation, a
   follow-up commit and the confirming commit can be given on any
   session, and they MUST include a <persist-id> element with a value
   equal to the given value of the <persist> element.
```

Example implementations of confirmed commit(There are other vendors who support confirmed commit but not listed here)-
1. Cisco - https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r3-9/system_management/command/reference/yr39xr12k_chapter5.html#wp1873946320 - Confirmed commit can be issued as part of CLI cmds - ` commit confirmed <seconds>` eg. `RP/0/0/CPU0:router(config)# commit confirmed 60`.  The confirmation can be issued by entering a `commit` in the same SSH session.

2. Juniper - https://www.juniper.net/documentation/us/en/software/junos/cli/topics/ref/command/commit.html - Confirmed commit can be issued as part of CLI cmds - `commit confirmed <minutes>`. Eg. `user@host# commit confirmed 1`. The confirmation can be issued by entering a `commit` or `commit check` in the same SSH session.

There is an _optional_ `comment` field that can be passed  which can hold any client provided description.
