### PR TITLE
Reset rollback duration on subsequent commit confirm operation.

### DIFF
--- a/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/gnmi_ext/gnmi_ext.proto
@@ -106,7 +106,9 @@ message Commit {
   // Required.
   string id = 1;
   oneof action {
-    // commit action creates a new commit. If a commit is on-going, server returns error.
+    // commit action creates a new commit. If a commit is on-going, server resets
+    // the rollback duration to a new provided value or sets the default value
+    // if one is omitted.
     CommitRequest commit = 2;
     // confirm action will confirm an on-going commit, the ID provided during confirm
     // should match the on-going commit ID.


### PR DESCRIPTION
This proposal brings rollback reset functionality to the gNMI Commit Confirmed extension.

## References to prior art

Any NOS compliant with [RFC6241 Netconf Commit Confirmed](https://datatracker.ietf.org/doc/html/rfc6241#section-8.4) capability supports resetting the rollback timeout on receiving new Commit Confirmed rpc:

A quote from the linked chapter:
> If a follow-up
   confirmed <commit> operation is issued before the timer expires, the
   timer is reset to the new value (600 seconds by default).

/cc @dplore @kidiyoor 