### PR TITLE
For gnmi_ext.proto, run protoc with github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto (this is for reflections).

### DIFF
--- a/compile_protos.sh
+++ b/compile_protos.sh
@@ -26,7 +26,7 @@ proto_imports_go=".:${protobufsrc}:${googleapis}:${GOPATH}/src"
 protoc -I=$proto_imports_go --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative,require_unimplemented_servers=false testing/fake/proto/fake.proto
 protoc -I=$proto_imports_go --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative,require_unimplemented_servers=false proto/gnmi/gnmi.proto
 protoc -I=$proto_imports_go --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative,require_unimplemented_servers=false proto/collector/collector.proto
-protoc -I=$proto_imports_go --go_out=. --go_opt=paths=source_relative proto/gnmi_ext/gnmi_ext.proto
+protoc -I=$proto_imports_go --go_out=${GOPATH}/src --go_opt=paths=source_relative github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto
 protoc -I=$proto_imports_go --go_out=. --go_opt=paths=source_relative proto/target/target.proto
 
 # Python


### PR DESCRIPTION
### The Problem
gNMI server reflections is basically facing the same issue as mentioned in https://github.com/fullstorydev/grpcurl/issues/22.  When the `gnmi_ext.proto` file gets compiled with path `proto/gnmi_ext/gnmi_ext.proto`, gNMI server reflection breaks with the following error:
```
Failed to resolve symbol "gnmi.gNMI": file "proto/gnmi/gnmi.proto" included an unresolvable reference to ".gnmi_ext.Extension"
```

### The Proposal
If `gnmi_ext.proto` gets compiled with `github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto`, gNMI server reflections work.  So, I modified the `gnmi_ext.proto` portion in `compile_protos.sh` to (only the go binding):
```
protoc -I=$proto_imports_go --go_out=${GOPATH}/src --go_opt=paths=source_relative github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto
```
I assumed that the `github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto` path is under `${GOPATH}/src`.  `$proto_imports_go` includes `${GOPATH}/src` so the go binding should be generated under `${GOPATH}/src/github.com/openconfig/gnmi/proto/gnmi_ext/`.

### Manual Testing
In my case, I have `gnmi_ext.proto` under `/vendor/github.com/openconfig/gnmi/proto/gnmi_ext/`.  When I did
```
protoc -I=vendor --go_out=vendor --go_opt=paths=source_relative github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto
```
The generated go binding's source is identified as `github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto` and the gNMI server reflections work.

### A Request
This is a message to the reviewer of this pull request.  Please modify the python binding portion of `compile_protos.sh` if necessary.  Also, please `compile_protos.sh` to modify `gnmi_ext.pb.go` under `${GOPATH}/src/github.com/openconfig/gnmi/proto/gnmi_ext/`.  Thank you.