### PR TITLE
Revert minimum required go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openconfig/gnmi
 
-go 1.23.4
+go 1.22.0
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.14


### PR DESCRIPTION
#192 updated the go.mod minimum version  to 1.23.4 which was unnecessary - there were no breaking API changes.  This reverts this change.