### PR TITLE
Use forked cc_grpc_library Bazel rules

### DIFF
--- a/.github/workflows/ci-cpp-build-gnmi.yml
+++ b/.github/workflows/ci-cpp-build-gnmi.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: recursive
       - name: Mount bazel cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: "~/.cache/bazel"
           key: bazel-${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
 bazel_dep(name = "gazelle", version = "0.41.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "grpc", version = "1.69.0", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "rules_go", version = "0.51.0", repo_name = "io_bazel_rules_go")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")

--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -1,0 +1,123 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generates and compiles C++ grpc stubs from proto_library rules.
+
+This is a copy of @com_github_grpc_grpc//bazel/cc_grpc_library.bzl including
+the fix in https://github.com/grpc/grpc/pull/38915.
+"""
+
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//bazel:generate_cc.bzl", "generate_cc")
+load("//bazel:protobuf.bzl", "well_known_proto_libs")
+
+def cc_grpc_library(
+        name,
+        srcs,
+        deps,
+        proto_only = False,
+        well_known_protos = False,
+        generate_mocks = False,
+        use_external = False,
+        grpc_only = False,
+        **kwargs):
+    """Generates C++ grpc classes for services defined in a proto file.
+
+    If grpc_only is True, this rule is compatible with proto_library and
+    cc_proto_library native rules such that it expects proto_library target
+    as srcs argument and generates only grpc library classes, expecting
+    protobuf messages classes library (cc_proto_library target) to be passed in
+    deps argument. By default grpc_only is False which makes this rule to behave
+    in a backwards-compatible mode (trying to generate both proto and grpc
+    classes).
+
+    Assumes the generated classes will be used in cc_api_version = 2.
+
+    Args:
+        name (str): Name of rule.
+        srcs (list): A single .proto file which contains services definitions,
+          or if grpc_only parameter is True, a single proto_library which
+          contains services descriptors.
+        deps (list): A list of C++ proto_library (or cc_proto_library) which
+          provides the compiled code of any message that the services depend on.
+        proto_only (bool): If True, create only C++ proto classes library,
+          avoid creating C++ grpc classes library (expect it in deps).
+          Deprecated, use native cc_proto_library instead. False by default.
+        well_known_protos (bool): Should this library additionally depend on
+          well known protos. Deprecated, the well known protos should be
+          specified as explicit dependencies of the proto_library target
+          (passed in srcs parameter) instead. False by default.
+        generate_mocks (bool): when True, Google Mock code for client stub is
+          generated. False by default.
+        use_external (bool): Not used.
+        grpc_only (bool): if True, generate only grpc library, expecting
+          protobuf messages library (cc_proto_library target) to be passed as
+          deps. False by default (will become True by default eventually).
+        **kwargs: rest of arguments, e.g., compatible_with and visibility
+    """
+    if len(srcs) > 1:
+        fail("Only one srcs value supported", "srcs")
+    if grpc_only and proto_only:
+        fail("A mutualy exclusive configuration is specified: grpc_only = True and proto_only = True")
+
+    extra_deps = []
+    proto_targets = []
+
+    if not grpc_only:
+        proto_target = name + "_only"
+        cc_proto_target = name if proto_only else name + "_cc_proto"
+
+        proto_deps = [dep + "_only" for dep in deps if dep.find(":") == -1]
+        proto_deps += [dep.split(":")[0] + ":" + dep.split(":")[1] + "_only" for dep in deps if dep.find(":") != -1 and dep.find("com_google_googleapis") == -1]
+        proto_deps += [dep for dep in deps if dep.find("com_google_googleapis") != -1]
+        if well_known_protos:
+            proto_deps += well_known_proto_libs()
+        proto_library(
+            name = proto_target,
+            srcs = srcs,
+            deps = proto_deps,
+            **kwargs
+        )
+
+        native.cc_proto_library(
+            name = cc_proto_target,
+            deps = [":" + proto_target],
+            **kwargs
+        )
+        extra_deps.append(":" + cc_proto_target)
+        proto_targets.append(proto_target)
+    else:
+        if not srcs:
+            fail("srcs cannot be empty", "srcs")
+        proto_targets += srcs
+
+    if not proto_only:
+        codegen_grpc_target = "_" + name + "_grpc_codegen"
+        generate_cc(
+            name = codegen_grpc_target,
+            srcs = proto_targets,
+            plugin = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
+            well_known_protos = well_known_protos,
+            generate_mocks = generate_mocks,
+            **kwargs
+        )
+
+        native.cc_library(
+            name = name,
+            srcs = [":" + codegen_grpc_target],
+            hdrs = [":" + codegen_grpc_target],
+            deps = deps +
+                   extra_deps +
+                   ["@com_github_grpc_grpc//:grpc++_codegen_proto"],
+            **kwargs
+        )

--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -1,0 +1,227 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generates C++ grpc stubs from proto_library rules.
+
+This is an internal rule used by cc_grpc_library, and shouldn't be used
+directly.
+
+This is a copy of @com_github_grpc_grpc//bazel/generate_cc.bzl including
+the fix in https://github.com/grpc/grpc/pull/38915.
+"""
+
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
+load(
+    "//bazel:protobuf.bzl",
+    "get_include_directory",
+    "get_out_dir",
+    "get_plugin_args",
+    "get_proto_arguments",
+    "get_proto_root",
+    "is_in_virtual_imports",
+    "proto_path_to_generated_filename",
+)
+
+_GRPC_PROTO_HEADER_FMT = "{}.grpc.pb.h"
+_GRPC_PROTO_SRC_FMT = "{}.grpc.pb.cc"
+_GRPC_PROTO_MOCK_HEADER_FMT = "{}_mock.grpc.pb.h"
+_PROTO_HEADER_FMT = "{}.pb.h"
+_PROTO_SRC_FMT = "{}.pb.cc"
+
+def _strip_package_from_path(label_package, file):
+    prefix_len = 0
+    if not file.is_source and file.path.startswith(file.root.path):
+        prefix_len = len(file.root.path) + 1
+
+    path = file.path
+    if len(label_package) == 0:
+        return path
+    if not path.startswith(label_package + "/", prefix_len):
+        fail("'{}' does not lie within '{}'.".format(path, label_package))
+    return path[prefix_len + len(label_package + "/"):]
+
+def _join_directories(directories):
+    massaged_directories = [directory for directory in directories if len(directory) != 0]
+    return "/".join(massaged_directories)
+
+def generate_cc_impl(ctx):
+    """Implementation of the generate_cc rule.
+
+    Args:
+      ctx: The context object.
+    Returns:
+      The provider for the generated files.
+    """
+    protos = [f for src in ctx.attr.srcs for f in src[ProtoInfo].check_deps_sources.to_list()]
+    includes = [
+        f
+        for src in ctx.attr.srcs
+        for f in src[ProtoInfo].transitive_imports.to_list()
+    ]
+    outs = []
+    proto_root = get_proto_root(
+        ctx.label.workspace_root,
+    )
+
+    label_package = _join_directories([ctx.label.workspace_root, ctx.label.package])
+    if ctx.executable.plugin:
+        outs += [
+            proto_path_to_generated_filename(
+                _strip_package_from_path(label_package, proto),
+                _GRPC_PROTO_HEADER_FMT,
+            )
+            for proto in protos
+        ]
+        outs += [
+            proto_path_to_generated_filename(
+                _strip_package_from_path(label_package, proto),
+                _GRPC_PROTO_SRC_FMT,
+            )
+            for proto in protos
+        ]
+        if ctx.attr.generate_mocks:
+            outs += [
+                proto_path_to_generated_filename(
+                    _strip_package_from_path(label_package, proto),
+                    _GRPC_PROTO_MOCK_HEADER_FMT,
+                )
+                for proto in protos
+            ]
+    else:
+        outs += [
+            proto_path_to_generated_filename(
+                _strip_package_from_path(label_package, proto),
+                _PROTO_HEADER_FMT,
+            )
+            for proto in protos
+        ]
+        outs += [
+            proto_path_to_generated_filename(
+                _strip_package_from_path(label_package, proto),
+                _PROTO_SRC_FMT,
+            )
+            for proto in protos
+        ]
+    out_files = [ctx.actions.declare_file(out) for out in outs]
+    out_dir_info = get_out_dir(protos, ctx)
+    output_dir = out_dir_info.path
+
+    arguments = []
+    if ctx.executable.plugin:
+        arguments += get_plugin_args(
+            ctx.executable.plugin,
+            ctx.attr.flags,
+            output_dir,
+            ctx.attr.generate_mocks,
+        )
+        tools = [ctx.executable.plugin]
+    else:
+        arguments.append("--cpp_out=" + ",".join(ctx.attr.flags) + ":" + output_dir)
+        tools = []
+
+    proto_root = get_proto_root(ctx.label.workspace_root)
+    dir_out = str(ctx.genfiles_dir.path + proto_root)
+    proto_paths = [dir_out]
+    for inc in includes:
+        inc_dir = get_include_directory(inc)
+        if inc_dir not in proto_paths:
+            proto_paths.append(inc_dir)
+    arguments += ["--proto_path={}".format(path) for path in proto_paths]
+
+    # Add proto files to compile.
+    arguments += get_proto_arguments(protos, ctx.genfiles_dir.path)
+
+    # create a list of well known proto files if the argument is non-None
+    well_known_proto_files = []
+    if ctx.attr.well_known_protos:
+        f = ctx.attr.well_known_protos.files.to_list()[0].dirname
+        if f != "external/com_google_protobuf/src/google/protobuf":
+            print(
+                "Error: Only @com_google_protobuf//:well_known_type_protos is supported",
+            )  # buildifier: disable=print
+        else:
+            # f points to "external/com_google_protobuf/src/google/protobuf"
+            # add -I argument to protoc so it knows where to look for the proto files.
+            arguments.append("-I{0}".format(f + "/../.."))
+            well_known_proto_files = [
+                f
+                for f in ctx.attr.well_known_protos.files.to_list()
+            ]
+
+    ctx.actions.run(
+        inputs = protos + includes + well_known_proto_files,
+        tools = tools,
+        outputs = out_files,
+        executable = ctx.executable._protoc,
+        arguments = arguments,
+        use_default_shell_env = True,
+    )
+
+    # Create symlinks from _virtual_imports to _virtual_includes for headers.
+    virtual_includes_files = []
+    for out_file in out_files:
+        if (is_in_virtual_imports(out_file) and
+            out_file.path.endswith(".grpc.pb.h")):
+            virtual_imports_str = "_virtual_imports"
+            path_idx = out_file.path.find(virtual_imports_str) + len(virtual_imports_str)
+            rel_path = out_file.path[path_idx:]
+            virtual_includes_path = "_virtual_includes" + rel_path
+            virtual_includes_file = ctx.actions.declare_file(virtual_includes_path)
+            ctx.actions.symlink(
+                output = virtual_includes_file,
+                target_file = out_file,
+            )
+            virtual_includes_files.append(virtual_includes_file)
+
+    return DefaultInfo(files = depset(out_files + virtual_includes_files))
+
+_generate_cc = rule(
+    attrs = {
+        "srcs": attr.label_list(
+            mandatory = True,
+            allow_empty = False,
+            providers = [ProtoInfo],
+        ),
+        "plugin": attr.label(
+            executable = True,
+            providers = ["files_to_run"],
+            cfg = "exec",
+        ),
+        "flags": attr.string_list(
+            mandatory = False,
+            allow_empty = True,
+        ),
+        "well_known_protos": attr.label(mandatory = False),
+        "generate_mocks": attr.bool(
+            default = False,
+            mandatory = False,
+        ),
+        "_protoc": attr.label(
+            default = Label("@com_google_protobuf//:protoc"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    # We generate .h files, so we need to output to genfiles.
+    output_to_genfiles = True,
+    implementation = generate_cc_impl,
+)
+
+def generate_cc(well_known_protos, **kwargs):
+    if well_known_protos:
+        _generate_cc(
+            well_known_protos = "@com_google_protobuf//:well_known_type_protos",
+            **kwargs
+        )
+    else:
+        _generate_cc(**kwargs)

--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -1,0 +1,345 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility functions for generating protobuf code.
+
+This is a copy of @com_github_grpc_grpc//bazel/protobuf.bzl including
+the fix in https://github.com/grpc/grpc/pull/38915.
+"""
+
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
+
+_PROTO_EXTENSION = ".proto"
+_VIRTUAL_IMPORTS = "/_virtual_imports/"
+
+_WELL_KNOWN_PROTOS_BASE = [
+    "any_proto",
+    "api_proto",
+    "compiler_plugin_proto",
+    "descriptor_proto",
+    "duration_proto",
+    "empty_proto",
+    "field_mask_proto",
+    "source_context_proto",
+    "struct_proto",
+    "timestamp_proto",
+    "type_proto",
+    "wrappers_proto",
+]
+
+def well_known_proto_libs():
+    return ["@com_google_protobuf//:" + b for b in _WELL_KNOWN_PROTOS_BASE]
+
+def is_well_known(label):
+    # Bazel surfaces labels as their underlying identity, even if they are referenced
+    # via aliases. Bazel also does not currently provide a way to find the real label
+    # underlying an alias. So the implementation detail that the WKTs present at the
+    # top level of the protobuf repo are actually backed by targets in the
+    # //src/google/protobuf package leaks through here.
+    # We include both the alias path and the underlying path to be resilient to
+    # reversions of this change as well as for continuing compatibility with repos
+    # that happen to pull in older versions of protobuf.
+    all_wkt_targets = (["@com_google_protobuf//:" + b for b in _WELL_KNOWN_PROTOS_BASE] +
+                       ["@com_google_protobuf//src/google/protobuf:" + b for b in _WELL_KNOWN_PROTOS_BASE])
+    return label in all_wkt_targets
+
+def get_proto_root(workspace_root):
+    """Gets the root protobuf directory.
+
+    Args:
+      workspace_root: context.label.workspace_root
+
+    Returns:
+      The directory relative to which generated include paths should be.
+    """
+    if workspace_root:
+        return "/{}".format(workspace_root)
+    else:
+        return ""
+
+def _strip_proto_extension(proto_filename):
+    if not proto_filename.endswith(_PROTO_EXTENSION):
+        fail('"{}" does not end with "{}"'.format(
+            proto_filename,
+            _PROTO_EXTENSION,
+        ))
+    return proto_filename[:-len(_PROTO_EXTENSION)]
+
+def proto_path_to_generated_filename(proto_path, fmt_str):
+    """Calculates the name of a generated file for a protobuf path.
+
+    For example, "examples/protos/helloworld.proto" might map to
+      "helloworld.pb.h".
+
+    Args:
+      proto_path: The path to the .proto file.
+      fmt_str: A format string used to calculate the generated filename. For
+        example, "{}.pb.h" might be used to calculate a C++ header filename.
+
+    Returns:
+      The generated filename.
+    """
+    return fmt_str.format(_strip_proto_extension(proto_path))
+
+def get_include_directory(source_file):
+    """Returns the include directory path for the source_file.
+
+    All of the include statements within the given source_file are calculated
+    relative to the directory returned by this method.
+
+    The returned directory path can be used as the "--proto_path=" argument
+    value.
+
+    Args:
+      source_file: A proto file.
+
+    Returns:
+      The include directory path for the source_file.
+    """
+    directory = source_file.path
+    prefix_len = 0
+
+    if is_in_virtual_imports(source_file):
+        root, relative = source_file.path.split(_VIRTUAL_IMPORTS, 2)
+        result = root + _VIRTUAL_IMPORTS + relative.split("/", 1)[0]
+        return result
+
+    if not source_file.is_source and directory.startswith(source_file.root.path):
+        prefix_len = len(source_file.root.path) + 1
+
+    if directory.startswith("external", prefix_len):
+        external_separator = directory.find("/", prefix_len)
+        repository_separator = directory.find("/", external_separator + 1)
+        return directory[:repository_separator]
+    else:
+        return source_file.root.path if source_file.root.path else "."
+
+def get_plugin_args(
+        plugin,
+        flags,
+        dir_out,
+        generate_mocks,
+        plugin_name = "PLUGIN"):
+    """Returns arguments configuring protoc to use a plugin for a language.
+
+    Args:
+      plugin: An executable file to run as the protoc plugin.
+      flags: The plugin flags to be passed to protoc.
+      dir_out: The output directory for the plugin.
+      generate_mocks: A bool indicating whether to generate mocks.
+      plugin_name: A name of the plugin, it is required to be unique when there
+      are more than one plugin used in a single protoc command.
+    Returns:
+      A list of protoc arguments configuring the plugin.
+    """
+    augmented_flags = list(flags)
+    if generate_mocks:
+        augmented_flags.append("generate_mock_code=true")
+
+    augmented_dir_out = dir_out
+    if augmented_flags:
+        augmented_dir_out = ",".join(augmented_flags) + ":" + dir_out
+
+    return [
+        "--plugin=protoc-gen-{plugin_name}={plugin_path}".format(
+            plugin_name = plugin_name,
+            plugin_path = plugin.path,
+        ),
+        "--{plugin_name}_out={dir_out}".format(
+            plugin_name = plugin_name,
+            dir_out = augmented_dir_out,
+        ),
+    ]
+
+def _make_prefix(label):
+    """Returns the directory prefix for a label.
+
+    @repo//foo/bar:sub/dir/file.proto  =>  'external/repo/foo/bar/'
+    //foo/bar:sub/dir/file.proto       =>  'foo/bar/'
+    //:sub/dir/file.proto              =>  ''
+
+    That is, the prefix can be removed from a file's full path to
+    obtain the file's relative location within the package's effective
+    directory."""
+
+    wsr = label.workspace_root
+    pkg = label.package
+
+    if not wsr and not pkg:
+        return ""
+    elif not wsr:
+        return pkg + "/"
+    elif not pkg:
+        return wsr + "/"
+    else:
+        return wsr + "/" + pkg + "/"
+
+def get_staged_proto_file(label, context, source_file):
+    """Copies a proto file to the appropriate location if necessary.
+
+    Args:
+      label: The label of the rule using the .proto file.
+      context: The ctx object for the rule or aspect.
+      source_file: The original .proto file.
+
+    Returns:
+      The original proto file OR a new file in the staged location.
+    """
+    if source_file.dirname == label.package or \
+       is_in_virtual_imports(source_file):
+        # Current target and source_file are in same package
+        return source_file
+    else:
+        # Current target and source_file are in different packages (most
+        # probably even in different repositories)
+        prefix = _make_prefix(source_file.owner)
+        copied_proto = context.actions.declare_file(source_file.path[len(prefix):])
+        context.actions.run_shell(
+            inputs = [source_file],
+            outputs = [copied_proto],
+            command = "cp {} {}".format(source_file.path, copied_proto.path),
+            mnemonic = "CopySourceProto",
+        )
+        return copied_proto
+
+def protos_from_context(context):
+    """Copies proto files to the appropriate location.
+
+    Args:
+      context: The ctx object for the rule.
+
+    Returns:
+      A list of the protos.
+    """
+    protos = []
+    for src in context.attr.deps:
+        for file in src[ProtoInfo].direct_sources:
+            protos.append(get_staged_proto_file(context.label, context, file))
+    return protos
+
+def includes_from_deps(deps):
+    """Get includes from rule dependencies."""
+    return [
+        file
+        for src in deps
+        for file in src[ProtoInfo].transitive_imports.to_list()
+    ]
+
+def get_proto_arguments(protos, genfiles_dir_path):
+    """Get the protoc arguments specifying which protos to compile.
+
+    Args:
+      protos: The protob files to supply.
+      genfiles_dir_path: The path to the genfiles directory.
+
+    Returns:
+      The arguments to supply to protoc.
+    """
+    arguments = []
+    for proto in protos:
+        strip_prefix_len = 0
+        if is_in_virtual_imports(proto):
+            incl_directory = get_include_directory(proto)
+            if proto.path.startswith(incl_directory):
+                strip_prefix_len = len(incl_directory) + 1
+        elif proto.path.startswith(genfiles_dir_path):
+            strip_prefix_len = len(genfiles_dir_path) + 1
+
+        arguments.append(proto.path[strip_prefix_len:])
+
+    return arguments
+
+def declare_out_files(protos, context, generated_file_format):
+    """Declares and returns the files to be generated.
+
+    Args:
+      protos: A list of files. The protos to declare.
+      context: The context object.
+      generated_file_format: A format string. Will be passed to
+        proto_path_to_generated_filename to generate the filename of each
+        generated file.
+
+    Returns:
+      A list of file providers.
+    """
+
+    out_file_paths = []
+    for proto in protos:
+        if not is_in_virtual_imports(proto):
+            prefix = _make_prefix(proto.owner)
+            full_prefix = context.genfiles_dir.path + "/" + prefix
+            if proto.path.startswith(full_prefix):
+                out_file_paths.append(proto.path[len(full_prefix):])
+            elif proto.path.startswith(prefix):
+                out_file_paths.append(proto.path[len(prefix):])
+        else:
+            out_file_paths.append(proto.path[proto.path.index(_VIRTUAL_IMPORTS) + 1:])
+
+    return [
+        context.actions.declare_file(
+            proto_path_to_generated_filename(
+                out_file_path,
+                generated_file_format,
+            ),
+        )
+        for out_file_path in out_file_paths
+    ]
+
+def get_out_dir(protos, context):
+    """Returns the value to supply to the --<lang>_out= protoc flag.
+
+    The result is based on the input source proto files and current context.
+
+    Args:
+        protos: A list of protos to be used as source files in protoc command
+        context: A ctx object for the rule.
+    Returns:
+        The value of --<lang>_out= argument.
+    """
+    at_least_one_virtual = 0
+    for proto in protos:
+        if is_in_virtual_imports(proto):
+            at_least_one_virtual = True
+        elif at_least_one_virtual:
+            fail("Proto sources must be either all virtual imports or all real")
+    if at_least_one_virtual:
+        out_dir = get_include_directory(protos[0])
+        ws_root = protos[0].owner.workspace_root
+        prefix = "/" + _make_prefix(protos[0].owner) + _VIRTUAL_IMPORTS[1:]
+
+        return struct(
+            path = out_dir,
+            import_path = out_dir[out_dir.find(prefix) + 1:],
+        )
+
+    out_dir = context.genfiles_dir.path
+    ws_root = context.label.workspace_root
+    if ws_root:
+        out_dir = out_dir + "/" + ws_root
+    return struct(path = out_dir, import_path = None)
+
+def is_in_virtual_imports(source_file, virtual_folder = _VIRTUAL_IMPORTS):
+    """Determines if source_file is virtual.
+
+    A file is virtual if placed in the _virtual_imports subdirectory. The
+    output of all proto_library targets which use import_prefix and/or
+    strip_import_prefix arguments is placed under _virtual_imports directory.
+
+    Args:
+        source_file: A proto file.
+        virtual_folder: The virtual folder name (is set to "_virtual_imports"
+            by default)
+    Returns:
+        True if source_file is located under _virtual_imports, False otherwise.
+    """
+    return not source_file.is_source and virtual_folder in source_file.path

--- a/proto/collector/BUILD.bazel
+++ b/proto/collector/BUILD.bazel
@@ -15,7 +15,7 @@
 # Supporting infrastructure for implementing and testing PINS.
 #
 
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")

--- a/proto/collector/BUILD.bazel
+++ b/proto/collector/BUILD.bazel
@@ -15,11 +15,11 @@
 # Supporting infrastructure for implementing and testing PINS.
 #
 
-load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/proto/gnmi/BUILD.bazel
+++ b/proto/gnmi/BUILD.bazel
@@ -15,7 +15,7 @@
 # Supporting infrastructure for implementing and testing PINS.
 #
 
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")

--- a/proto/gnmi/BUILD.bazel
+++ b/proto/gnmi/BUILD.bazel
@@ -15,11 +15,11 @@
 # Supporting infrastructure for implementing and testing PINS.
 #
 
-load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/testing/fake/proto/BUILD.bazel
+++ b/testing/fake/proto/BUILD.bazel
@@ -13,11 +13,11 @@
 # limitations under the License.
 #
 
-load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/testing/fake/proto/BUILD.bazel
+++ b/testing/fake/proto/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")


### PR DESCRIPTION
The cc_grpc_library build rule in grpc does not support the import_prefix defined on proto_library rule.  An example can be seen by any user trying to build the c++ GRPC protos on gnmi@0.13.0:

```shell
mkdir example ; cd example
cat >MODULE.bazel <<EOF
module(name = "user")
bazel_dep(name = "openconfig_gnmi", version = "0.13.0")
EOF
bazel build @openconfig_gnmi//proto/gnmi:gnmi_cc_grpc_proto
....
Could not make proto path relative: external/openconfig_gnmi+/proto/gnmi/_virtual_imports/gnmi_proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto: No such file or directory
```

With this patch applied this builds successfully. I am hoping this fix can be included upstream and we can revert this PR.