### PR TITLE
Addition of YANG compliance TypedValue enum variants

### DIFF
--- a/proto/gnmi/gnmi.proto
+++ b/proto/gnmi/gnmi.proto
@@ -38,7 +38,7 @@ extend google.protobuf.FileOptions {
 
 // gNMI_service is the current version of the gNMI service, returned through
 // the Capabilities RPC.
-option (gnmi_service) = "0.10.0";
+option (gnmi_service) = "0.11.0";
 
 option go_package = "github.com/openconfig/gnmi/proto/gnmi";
 option java_multiple_files = true;
@@ -132,6 +132,10 @@ message TypedValue {
     // github.com/openconfig/reference/blob/master/rpc/gnmi/protobuf-vals.md
     // for a complete specification. [Experimental]
     bytes proto_bytes = 13;
+    // Set to true for YANG modeled nodes containing presence statement.
+    bool presence_val = 15;
+    // Set to true for YANG modeled nodes of type empty.
+    bool empty_val = 16;
   }
 }
 


### PR DESCRIPTION
- Support for a means to describe nodes (containers) that contain the
  YANG `presence` statement in gNMI Updates
- Support for a means to describe nodes of type empty (leafs) in gNMI Updates

Description:

As of today, gNMI is meant to be a protocol to access and interact with data on
an endpoint somewhat agnostic of the data content and how the content is
described/modeled.  There is however a contract of sorts from an `origin`
perspective that at least describes how to interact with data modeled in YANG
specific to the OpenConfig model set for the origin = `openconfig`.

As part of the OpenConfig modeling guidelines, only a subset of the YANG
language is recommended with some being more or less forbidden.  One such case
is YANG `presence` containers described
[here](https://openconfig.net/docs/guides/style_guide/#presence).

While other undefined origins can define separate rules to abide by, there is
still a common contract and API defintion that must be shared thus we currently
have gaps for the marrying of YANG modeled data to how such content can be
fully described and properly typed within gNMI message structs.

This PR covers 2 such gaps for YANG statements:

* `presence "...";`
* `type empty;`

Example usage for YANG modeled `presence` container:

```
  update:  {
    path:  {
      elem:  {
        name:  "configuration"
      }
      elem:  {
        name:  "system"
      }
      elem:  {
        name:  "services"
      }
      elem:  {
        name:  "ftp"
    }
    val:  {
      presence_val:  true
    }
  }
```

And subsequent deletion (non issue for this PR)

```
  update:  {
    timestamp:  1743611293000000000
    delete:  {
      elem:  {
        name:  "configuration"
      }
      elem:  {
        name:  "system"
      }
      elem:  {
        name:  "services"
      }
      elem:  {
        name:  "ftp"
      }
    }
  }
```

Example usage for YANG modeled type `empty`

```
  update:  {
    path:  {
      elem:  {
        name:  "configuration"
      }
      elem:  {
        name:  "system"
      }
      elem:  {
        name:  "foo"
      }
      elem:  {
        name:  "bar"
    }
    val:  {
      empty_val:  true
    }
  }
```

And subsequent deletion (non issue for this PR)

```
  update:  {
    timestamp:  1743611293000000000
    delete:  {
      elem:  {
        name:  "configuration"
      }
      elem:  {
        name:  "system"
      }
      elem:  {
        name:  "foo"
      }
      elem:  {
        name:  "bar"
      }
    }
  }
```

