### PR TITLE
Add Renovate configuration file.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "extends": ["config:recommended", "schedule:weekdays", ":semanticCommitsDisabled"],
+  "postUpdateOptions": ["gomodTidy"],
+  "commitMessagePrefix": "chore(all): ",
+  "commitMessageAction": "update",
+  "groupName": "deps",
+  "ignoreDeps": ["com_google_googleapis"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Synchronize Go Version: MODULE.bazel go_sdk",
+      "managerFilePatterns": ["MODULE.bazel"],
+      "matchStrings": [
+        "go_sdk\\.download\\(version\\s*=\\s*\"(?<currentValue>[\\d\\.]+)\"\\)"
+      ],
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "golang-version"
+    }
+  ]
+}


### PR DESCRIPTION
Add configuration for [renovate](https://www.mend.io/renovate/). The intent is to use renovate instead of dependabot for helping with dependency chores. Renovate supports updating bazel/go toolchains, go modules, bzlmod, docker, and Github Actions, while dependabot only supports updating go modules.

We will use [Forking Renovate](https://github.com/apps/forking-renovate) so we do not need to give direct write permissions to the bot.