### PR TITLE
Added a single snapshot time for GetResponse

### DIFF
--- a/proto/gnmi/gnmi.proto
+++ b/proto/gnmi/gnmi.proto
@@ -433,6 +433,7 @@ message GetResponse {
   // Extension messages associated with the GetResponse. See the
   // gNMI extension specification for further definition.
   repeated gnmi_ext.Extension extension = 3;
+  optional int64 timestamp = 4; // snapshot time when data collection is complete.
 }
 
 // CapabilityRequest is sent by the client in the Capabilities RPC to request


### PR DESCRIPTION
The data collected for each individual path in the notification, may carry a different timestamp from other paths. In that case, there is no single view of the complete data for the list of paths in the GetRequest.  From a target's perspective the collection for a Subscribe request and a Get request is identical and only the mode of transport of those notification is different. The individual notification gives the timestamp of the collected data of the relevant path in a distributed environment. The target waits for all the individual collections to complete, pack it into a single Get response and send it.   With this change, we introduce a timestamp for the entire snapshot, attached when the collection is complete for all the paths and the packet is ready to be sent to the client.